### PR TITLE
mac: use correct parameters for SecPolicyCreateSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Retrieves trusted certificates from the operating system using platform-specific
 
 See javadoc at [NativeTrustedCertificates.java](https://github.com/JetBrains/jvm-native-trusted-roots/blob/trunk/src/main/java/org/jetbrains/nativecerts/NativeTrustedCertificates.java)
 
+## Compatibility flags
+
+* Previously intermediate certificates were validated without explicitly specifying "server" policy \
+  See https://developer.apple.com/documentation/security/secpolicycreatessl(_:_:)
+  Now they are. To revert to the previous behavior, pass `-Dorg.jetbrains.nativecerts.mac.server_policy=false` in the JVM options.
+
 ## On-site diagnostics
 
 If something goes wrong on user's machine, it's possible to gather all debug logging running a special CLI utility:

--- a/src/main/java/org/jetbrains/nativecerts/mac/SecurityFrameworkUtil.java
+++ b/src/main/java/org/jetbrains/nativecerts/mac/SecurityFrameworkUtil.java
@@ -29,6 +29,13 @@ import static org.jetbrains.nativecerts.NativeTrustedRootsInternalUtils.renderEx
 public class SecurityFrameworkUtil {
     private final static Logger LOGGER = Logger.getLogger(SecurityFrameworkUtil.class.getName());
 
+    public static final String SERVER_POLICY_PROPERTY = "org.jetbrains.nativecerts.mac.server_policy";
+    /**
+     * "server" policy should be used for evaluating certificates, but previously it was not.
+     * This option is to retain compatibility.
+     */
+    private final static boolean ourIsServerPolicy = Boolean.parseBoolean(System.getProperty(SERVER_POLICY_PROPERTY, "true"));
+
     private SecurityFrameworkUtil() {
     }
 
@@ -183,7 +190,13 @@ public class SecurityFrameworkUtil {
 
             secTrustRefByReference = new SecurityFramework.SecTrustRefByReference();
 
-            policy = SecurityFramework.INSTANCE.SecPolicyCreateSSL(false, null);
+            if (!ourIsServerPolicy) {
+                LOGGER.warning(
+                        "Using 'client' policy for certificate validation, this is not recommended. " +
+                        "Drop setting of '" + SERVER_POLICY_PROPERTY + "' property from JVM options to use 'server' policy by default.");
+            }
+
+            policy = SecurityFramework.INSTANCE.SecPolicyCreateSSL(ourIsServerPolicy, null);
             SecurityFramework.OSStatus rc = SecurityFramework.INSTANCE.SecTrustCreateWithCertificates(
                     subjCerts, policy, secTrustRefByReference);
             if (!SecurityFramework.OSStatus.errSecSuccess.equals(rc)) {

--- a/src/test/gen-mock-ca.sh
+++ b/src/test/gen-mock-ca.sh
@@ -20,6 +20,10 @@ openssl genrsa -out intermediate.key 2048
 openssl req -new -sha256 -nodes -key intermediate.key  \
   -subj "/O=JETBRAINS/CN=JVM-NATIVE-TRUSTED-ROOTS-MOCK-INTERMEDIATE-CA" -out test-intermediate-ca.csr
 
+# Short-lived intermediate cert lifetime is required for apple checks
+# https://support.apple.com/en-au/102028
+# but looks like "This change will not affect certificates issued from user-added or administrator-added Root CAs."
+# is false for intermediate certs
 openssl x509 -req \
  -extensions v3_ca \
  -extfile openssl.cnf \
@@ -28,7 +32,7 @@ openssl x509 -req \
  -CAkey root.key \
  -CAcreateserial \
  -out intermediate-ca.pem \
- -days 10950 \
+ -days 100 \
  -sha256
 
 openssl genrsa -out client.key 2048


### PR DESCRIPTION
we need to validate our cert as a server certificate